### PR TITLE
Added Gear Search Form Functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'pry'
-  gem 'rspec-rails'
+  gem 'capybara'
 
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     bcrypt (3.1.13)
     bindex (0.8.1)
@@ -49,6 +51,14 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.32.2)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -93,6 +103,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.5)
     puma (3.12.6)
     rack (2.2.2)
     rack-test (1.1.0)
@@ -125,6 +136,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (1.7.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -181,6 +193,8 @@ GEM
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -189,6 +203,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
+  capybara
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,6 @@
+class SearchController<ApplicationController
+
+  def new
+  end
+  
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,5 +2,8 @@ class SearchController<ApplicationController
 
   def new
   end
-  
+
+  def index
+  end
+
 end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,1 @@
+<h1 align=center>Here are your search results:</h1>

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -1,0 +1,23 @@
+<h1 align= "center">Find the Gear for Your Next Adventure!</h1>
+
+<center>
+
+<h2>What are you looking for?</h2>
+
+<%= form_tag '/search', method: :post do |f| %>
+
+<%= label_tag :keywords %>
+<%= text_field_tag :keywords %><br>
+
+<%= label_tag :location %>
+<%= text_field_tag :location %><br>
+
+<%= label_tag :pick_up_date %>
+<%= date_field_tag :start_date %><br>
+
+<%= label_tag :return_date %>
+<%= date_field_tag :end_date %><br>
+
+<%= submit_tag 'Search' %>
+<% end %>
+</center>

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -2,15 +2,18 @@
 
 <center>
 
-<h2>What gear are you looking for?</h2>
+<h2>What do you want to rent?</h2>
 
-<%= form_tag '/search', method: :post do |f| %>
+<%= form_tag '/search', method: :get do |f| %>
 
-<%= label_tag :keywords %>
-<%= text_field_tag :keywords %><br>
+<%= label_tag "Type of Gear" %><br>
+<%= text_field_tag :keyword %><br>
 
-<%= label_tag :location %>
+<%= label_tag "Pickup location (city, state)" %><br>
 <%= text_field_tag :location %><br>
+
+<%= label_tag "How many miles can you travel to pick it up?" %></br>
+<%= number_field_tag :distance %><br>
 
 <%= label_tag :pick_up_date %>
 <%= date_field_tag :start_date %><br>

--- a/app/views/search/new.html.erb
+++ b/app/views/search/new.html.erb
@@ -1,8 +1,8 @@
-<h1 align= "center">Find the Gear for Your Next Adventure!</h1>
+<h1 align= "center">Welcome to Gear Hub!</h1>
 
 <center>
 
-<h2>What are you looking for?</h2>
+<h2>What gear are you looking for?</h2>
 
 <%= form_tag '/search', method: :post do |f| %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get "/", to: "search#new"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get "/", to: "search#new"
+  get "/search", to: "search#index"
 end

--- a/spec/features/user_can_search_for_gear_spec.rb
+++ b/spec/features/user_can_search_for_gear_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe "as a visitor or user" do
+  describe "when I visit the search page" do
+    before(:each) do
+      collin = Owner.create(name: 'Collin')
+      ashley = Owner.create(name: 'Ashley')
+
+      snowboard = GearItem.create(name: 'Snowboard', description: 'a board to snow', price: 250.5, condition: 0, status: 0, location: '80204', owner: collin)
+      bike = GearItem.create(name: 'BMX', description: 'fastest bike in town', price: 2.5, condition: 0, status: 0, location: '80019', owner: collin)
+      helmet = GearItem.create(name: 'Helmet', description: 'this will protect your head', price: 45.0, condition: 0, status: 0, location: '80203', owner: collin)
+      tent = GearItem.create(name: 'Tent', description: 'this tent will protect you from thunder', price: 224.5, condition: 0, status: 0, location: '38655', owner: collin)
+      camper = GearItem.create(name: 'Purple Helmet', description: 'snazzier head protection', price: 200.5, condition: 0, status: 0, location: '80222', owner: collin)
+
+      skates = GearItem.create(name: 'Snow Shoes', description: 'trek through the snow', price: 85.5, condition: 0, status: 0, location: '38655', owner: ashley)
+      ski = GearItem.create(name: 'Helmet', description: 'helmet to protect you', price: 100.5, condition: 0, status: 0, location: '40403', owner: ashley)
+      bench = GearItem.create(name: 'Bench', description: 'you sit on this', price: 95.0, condition: 0, status: 0, location: '80227', owner: ashley)
+    end
+
+    it "I can enter a location, keywords, and dates to search for matching gear to rent" do
+
+      visit '/'
+
+      fill_in :location, with: "Denver, CO"
+      fill_in :keywords, with: "helmet, snow"
+      fill_in :start_date, with: "2020-08-10"
+      fill_in :end_date, with: "2020-08-15"
+
+      click_button "Search"
+
+      expect(current_path).to eq("/search_results")
+      expect(page).to have_content "Here are your search results:"
+
+    end
+  end
+end

--- a/spec/features/user_can_search_for_gear_spec.rb
+++ b/spec/features/user_can_search_for_gear_spec.rb
@@ -22,13 +22,14 @@ describe "as a visitor or user" do
       visit '/'
 
       fill_in :location, with: "Denver, CO"
-      fill_in :keywords, with: "helmet, snow"
+      fill_in :keyword, with: "helmet"
+      fill_in :distance, with: 15
       fill_in :start_date, with: "08/10/2020"
       fill_in :end_date, with: "08/15/2020"
 
       click_button "Search"
 
-      expect(current_path).to eq("/search_results")
+      expect(current_path).to eq("/search")
       expect(page).to have_content "Here are your search results:"
 
     end

--- a/spec/features/user_can_search_for_gear_spec.rb
+++ b/spec/features/user_can_search_for_gear_spec.rb
@@ -23,8 +23,8 @@ describe "as a visitor or user" do
 
       fill_in :location, with: "Denver, CO"
       fill_in :keywords, with: "helmet, snow"
-      fill_in :start_date, with: "2020-08-10"
-      fill_in :end_date, with: "2020-08-15"
+      fill_in :start_date, with: "08/10/2020"
+      fill_in :end_date, with: "08/15/2020"
 
       click_button "Search"
 


### PR DESCRIPTION
## Description
Added route `get "/", to: "search#new"` --> Form for users to search for gear by filling out location, keyword, distance they'll travel, start date, and end date
Added route `get "/search", to: "search#index"` --> Search results page (currently blank) with controller action that receives form results as params

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which maintains existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Notes
I think we might need to add simplecov to the project? When I run RSpec, I see the examples/failures but not the coverage percentage.

## RSpec Results
27 examples, 0 failures
```

```
